### PR TITLE
Add pip install

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+# Default Linux installation doesn't have pip. Install and update for both Python versions for good measure
+sudo apt-get install python-pip python3-pip --yes
+sudo python3 -m pip install pip --upgrade
+sudo python -m pip install pip --upgrade
+
 sudo pip install vcstool
 
 if [ ! -d "../riptide_software/src" ]; then


### PR DESCRIPTION
Going through our full setup right now, and the default install doesn't have pip, which is why vcs doesn't install, which leads to several issues down the road. Installing pip first thing fixes this. 